### PR TITLE
tweet link fallback removed

### DIFF
--- a/lib/social_buttons/view_helpers/tweet.rb
+++ b/lib/social_buttons/view_helpers/tweet.rb
@@ -19,7 +19,6 @@ module SocialButtons
 
       html = "".html_safe
       html << clazz::Scripter.new(self).script
-      html << link_to("Tweet", TWITTER_SHARE_URL, params)
       html
     end
 


### PR DESCRIPTION
Removing "tweet" link from social buttons, which was visible on lazy loading. Same effect as the previous pull request.

@stephenkerrhs made me do it :)

OLD
![screen shot 2015-06-08 at 12 50 28](https://cloud.githubusercontent.com/assets/3593843/8034485/00a5a864-0de0-11e5-97fb-d4969ac09411.png)

NEW
![screen shot 2015-06-08 at 12 50 34](https://cloud.githubusercontent.com/assets/3593843/8034484/fec3319c-0ddf-11e5-876f-5edb4db4e101.png)
