### PR TITLE
Revert "tweet link fallback removed"

### DIFF
--- a/lib/social_buttons/view_helpers/tweet.rb
+++ b/lib/social_buttons/view_helpers/tweet.rb
@@ -19,6 +19,7 @@ module SocialButtons
 
       html = "".html_safe
       html << clazz::Scripter.new(self).script
+      html << link_to("Tweet", TWITTER_SHARE_URL, params)
       html
     end
 


### PR DESCRIPTION
Reverts HomeStayTravel/social-buttons#4

Could not remove "Tweet" link from code successfully. Making link transparent in css in homestay.com repository
